### PR TITLE
Fix font-awesome version to 4.7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php" : "~5.5|~7.0",
         "yiisoft/yii2": ">=2.0.8",
-        "bower-asset/font-awesome": ">=4.7.0",
+        "bower-asset/font-awesome": "4.7.0",
         "bower-asset/toastr": ">=2.1.3",
         "bower-asset/dropzone": ">=4.3.0",
         "yiisoft/yii2-bootstrap": "^2.0"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php" : "~5.5|~7.0",
         "yiisoft/yii2": ">=2.0.8",
-        "bower-asset/font-awesome": "4.7.0",
+        "bower-asset/font-awesome": "~4.7.0",
         "bower-asset/toastr": ">=2.1.3",
         "bower-asset/dropzone": ">=4.3.0",
         "yiisoft/yii2-bootstrap": "^2.0"


### PR DESCRIPTION
Font-awesome 5.0 has been released and sadly does not have the same directory structure as the older versions. So, it is safe to lock it on 4.7.0 for now