### PR TITLE
[Fix] : Clear error while populating file input

### DIFF
--- a/src/public-assets/js/components/form.js
+++ b/src/public-assets/js/components/form.js
@@ -23,6 +23,10 @@ App.Components.Form = (function ($) {
                 }
                 element.attr('checked', shouldCheck);
             } else {
+                if (element.files.length > 0) {
+                    return;
+                }
+
                 if (element.is('select')) {
                     element.attr('data-selected', value);
                 }

--- a/src/public-assets/js/components/form.js
+++ b/src/public-assets/js/components/form.js
@@ -23,7 +23,7 @@ App.Components.Form = (function ($) {
                 }
                 element.attr('checked', shouldCheck);
             } else {
-                if (element.files.length > 0) {
+                if (element.attr('type') === 'file') {
                     return;
                 }
 


### PR DESCRIPTION
This fix prevents attempts to populate file input in forms. This currently generates errors in the console